### PR TITLE
ValidationError: Rename NO_ERROR to NO_VALIDATION_ERROR

### DIFF
--- a/js/security/v2/validation-error.js
+++ b/js/security/v2/validation-error.js
@@ -37,7 +37,7 @@ var ValidationError = function ValidationError(code, info)
 
 exports.ValidationError = ValidationError;
 
-ValidationError.NO_ERROR =                    0;
+ValidationError.NO_VALIDATION_ERROR =         0;
 ValidationError.INVALID_SIGNATURE =           1;
 ValidationError.NO_SIGNATURE =                2;
 ValidationError.CANNOT_RETRIEVE_CERTIFICATE = 3;
@@ -73,7 +73,7 @@ ValidationError.prototype.toString = function()
 {
   var result;
 
-  if (this.code_ === ValidationError.NO_ERROR)
+  if (this.code_ === ValidationError.NO_VALIDATION_ERROR)
     result = "No error";
   else if (this.code_ === ValidationError.INVALID_SIGNATURE)
     result = "Invalid signature";


### PR DESCRIPTION
The ndn-ind pull request https://github.com/operantnetworks/ndn-ind/pull/51 renames `ValidationError.NO_ERROR` to `NO_VALIDATION_ERROR` in order to avoid conflicts with winerror.h . Even though the JavaScript code doesn't include a Windows header file, we should keep the naming consistent. This pull request does the same renaming. As mentioned in the other pull request, this should have minimal impact: Normally an NDN application does not use ValidationError constants directly, but uses the error string output. Also, an application normally would not check for the "no error" condition but would only check error constants if there was an error.